### PR TITLE
RANGER-5244: Add UBI base image with CI enabled in ubi branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
-          context: ./docker
+          context: docker/*
           file: docker/Dockerfile
           build-args: RANGER_BASE_JAVA_VERSION
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,6 +87,7 @@ jobs:
         if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
+          context: docker
           file: docker/Dockerfile
           build-args: RANGER_BASE_JAVA_VERSION
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,11 +86,7 @@ jobs:
         run: |
           if [ "${RANGER_BASE_JAVA_VERSION}" = "8" ]; then
             echo "RANGER_BASE_JAVA_VERSION=1.8.0" >> $GITHUB_ENV
-          else
-            echo "RANGER_BASE_JAVA_VERSION=${RANGER_BASE_JAVA_VERSION}" >> $GITHUB_ENV
           fi
-        env:
-          RANGER_BASE_JAVA_VERSION: ${{ env.RANGER_BASE_JAVA_VERSION }}
 
       - name: Build and push image to GitHub Container Registry
         id: build
@@ -98,7 +94,7 @@ jobs:
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
           context: "{{defaultContext}}:docker"
-          build-args: RANGER_BASE_JAVA_VERSION=${{ env.RANGER_BASE_JAVA_VERSION }}
+          build-args: RANGER_BASE_JAVA_VERSION
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ on:
       java-version:
         type: string
         description: "JDK version (default: 8)"
-        default: '1.8.0'
+        default: '8'
         required: false
     outputs:
       image-id:
@@ -82,13 +82,23 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Optionally Update Java Version
+        run: |
+          if [ "${RANGER_BASE_JAVA_VERSION}" = "8" ]; then
+            echo "RANGER_BASE_JAVA_VERSION=1.8.0" >> $GITHUB_ENV
+          else
+            echo "RANGER_BASE_JAVA_VERSION=${RANGER_BASE_JAVA_VERSION}" >> $GITHUB_ENV
+          fi
+        env:
+          RANGER_BASE_JAVA_VERSION: ${{ env.RANGER_BASE_JAVA_VERSION }}
+
       - name: Build and push image to GitHub Container Registry
         id: build
         if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
           context: "{{defaultContext}}:docker"
-          build-args: RANGER_BASE_JAVA_VERSION
+          build-args: RANGER_BASE_JAVA_VERSION=${{ env.RANGER_BASE_JAVA_VERSION }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
-          context: docker
+          context: ./docker
           file: docker/Dockerfile
           build-args: RANGER_BASE_JAVA_VERSION
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ on:
       java-version:
         type: string
         description: "JDK version (default: 8)"
-        default: '8'
+        default: '1.8.0'
         required: false
     outputs:
       image-id:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ steps.pull.outputs.success == 'false' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
-          context: docker/*
+          context: "{{defaultContext}}:docker"
           file: docker/Dockerfile
           build-args: RANGER_BASE_JAVA_VERSION
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,6 @@ jobs:
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
           context: "{{defaultContext}}:docker"
-          file: docker/Dockerfile
           build-args: RANGER_BASE_JAVA_VERSION
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/build-and-tag.yaml
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 1.8.0, 11, 17 ]
       fail-fast: false
     with:
       java-version: ${{ matrix.java }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/build-and-tag.yaml
     strategy:
       matrix:
-        java: [ 1.8.0, 11, 17 ]
+        java: [ 8, 11, 17 ]
       fail-fast: false
     with:
       java-version: ${{ matrix.java }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,29 +14,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# see https://hub.docker.com/_/eclipse-temurin/tags
-ARG RANGER_BASE_JAVA_VERSION=8
+# see https://hub.docker.com/r/redhat/ubi9-minimal/tags
+ARG UBI_VERSION=latest
+FROM redhat/ubi9-minimal:${UBI_VERSION}
 
-# Ubuntu 22.04 LTS
-FROM eclipse-temurin:${RANGER_BASE_JAVA_VERSION}-jdk-jammy
+ARG RANGER_BASE_JAVA_VERSION=1.8.0
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
+    install -y java-${RANGER_BASE_JAVA_VERSION}-openjdk-devel \
+    && microdnf clean all \
+    && rpm -q java-${RANGER_BASE_JAVA_VERSION}-openjdk-devel
 
+ENV JAVA_HOME="/usr/lib/jvm/java-${RANGER_BASE_JAVA_VERSION}" \
+    JAVA_VENDOR="openjdk" \
+    JAVA_VERSION="${RANGER_BASE_JAVA_VERSION}" \
+    JBOSS_CONTAINER_OPENJDK_JDK_MODULE="/opt/jboss/container/openjdk/jdk"
+
+COPY ./requirements.txt /tmp
 # Install packages
-RUN apt update -q \
-    && DEBIAN_FRONTEND="noninteractive" apt install -y --no-install-recommends \
-        bc \
-        iputils-ping \
-        pdsh \
+RUN microdnf install -y \
         python3 \
         python3-pip \
-        python-is-python3 \
-        ssh \
-        tzdata \
+        bc \
+        iputils \
+        hostname \
+        tar \
+        gzip \
+        procps \
         vim \
-        xmlstarlet \
-    && apt clean
+        shadow-utils \
+        util-linux-user \
+        sudo \
+        initscripts \
+        openssh-clients \
+        openssh-server \
+        wget \
+    &&  microdnf clean all
 
 # Install Python modules
-RUN pip install apache-ranger requests \
+RUN pip install --no-cache-dir -r /tmp/requirements.txt apache-ranger requests \
     && rm -rf ~/.cache/pip
 
 # Set environment variables
@@ -44,6 +59,8 @@ ENV RANGER_DIST=/home/ranger/dist
 ENV RANGER_SCRIPTS=/home/ranger/scripts
 ENV RANGER_HOME=/opt/ranger
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN sed -i 's/^HOME_MODE.*/HOME_MODE 0755/' /etc/login.defs
 
 # setup groups, users, directories
 RUN groupadd ranger \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,6 +48,7 @@ RUN microdnf install -y \
         openssh-clients \
         openssh-server \
         wget \
+    &&  ln -s /usr/bin/python3 /usr/bin/python \
     &&  microdnf clean all
 
 # Install Python modules

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -21,4 +21,4 @@ set -u -o pipefail
 docker build \
   --build-arg RANGER_BASE_JAVA_VERSION \
   -t apache/ranger-base:dev \
-  "$@" - < Dockerfile
+  "$@" .

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,2 @@
+apache-ranger == 0.0.12
+requests == 2.32.4


### PR DESCRIPTION
## What changes were proposed in this pull request?

Moving support for UBI base image in apache/ranger-tools
- `ubi` branch to be used for UBI base image development
- CI builds to run on-demand from this branch as well 


## How was this patch tested?
Ranger core services: `ranger`, `ranger-usersync`, `ranger-tagsync` and `ranger-kms` come up successfully in containers using this base image.