### PR TITLE
RANGER-5524: Bump GitHub Action versions

### DIFF
--- a/.github/workflows/build-and-tag-ranger-image.yaml
+++ b/.github/workflows/build-and-tag-ranger-image.yaml
@@ -46,17 +46,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to GitHub Container Registry
         id: login
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -110,7 +110,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Add Docker Hub to targets
         if: ${{ env.DOCKERHUB_USER }}
@@ -124,7 +124,7 @@ jobs:
           docker pull ghcr.io/${{ github.repository_owner }}/ranger-solr:${RANGER_VERSION}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USER }}
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -42,7 +42,7 @@ jobs:
       REGISTRIES: ghcr.io # docker.io is appended dynamically
     steps:
       - name: Generate tags
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: |
             ${{ github.repository_owner }}/ranger-base
@@ -62,7 +62,7 @@ jobs:
           docker pull "$IMAGE_ID"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USER }}
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Generate image ID
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/ranger-base
@@ -67,16 +67,16 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Set up Docker Buildx
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to GitHub Container Registry
         id: login
         if: ${{ github.event_name != 'pull_request' && steps.pull.outputs.success == 'false' }}
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -85,7 +85,7 @@ jobs:
       - name: Build and push image to GitHub Container Registry
         id: build
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           file: docker/Dockerfile
           build-args: RANGER_BASE_JAVA_VERSION


### PR DESCRIPTION
## What changes were proposed in this pull request?

Node.js 20 is [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) in GitHub runners. Bump GitHub actions versions to the latest ones for Node.js 24 support.


## How was this patch tested?

CI: https://github.com/apache/ranger-tools/actions/runs/23412668511

Verified that all workflows use the same versions:

```
$ grep --no-filename -- '-action' .github/workflows/*.* | sed 's/^.*uses: //' | sort -u
docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a

```