### PR TITLE
RANGER-5727: Upgrade OS to Ubuntu 26.04 LTS, comes with Python 3.14

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN apt update -q \
 ENV RANGER_DIST=/home/ranger/dist
 ENV RANGER_SCRIPTS=/home/ranger/scripts
 ENV RANGER_HOME=/opt/ranger
-ENV PATH="${JAVA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/venv/bin"
+ENV PATH="/opt/venv/bin:${JAVA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 RUN python3 -m venv /opt/venv
 RUN /opt/venv/bin/pip install apache-ranger

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,35 +17,32 @@
 # see https://hub.docker.com/_/eclipse-temurin/tags
 ARG RANGER_BASE_JAVA_VERSION=8
 
-# Ubuntu 22.04 LTS
-FROM eclipse-temurin:${RANGER_BASE_JAVA_VERSION}-jdk-jammy
+# Ubuntu 26.04 LTS
+FROM eclipse-temurin:${RANGER_BASE_JAVA_VERSION}-jdk-resolute
 
-# Install packages
 RUN apt update -q \
     && DEBIAN_FRONTEND="noninteractive" apt install -y --no-install-recommends \
         bc \
         curl \
         iputils-ping \
         pdsh \
-        python3 \
-        python3-pip \
-        python-is-python3 \
         ssh \
         tzdata \
         vim \
         xmlstarlet \
         krb5-user \
-    && apt clean
-
-# Install Python modules
-RUN pip install apache-ranger requests \
-    && rm -rf ~/.cache/pip
+        python3-venv \
+    &&  apt clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set environment variables
 ENV RANGER_DIST=/home/ranger/dist
 ENV RANGER_SCRIPTS=/home/ranger/scripts
 ENV RANGER_HOME=/opt/ranger
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH="${JAVA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/venv/bin"
+
+RUN python3 -m venv /opt/venv
+RUN /opt/venv/bin/pip install apache-ranger
 
 # create directories and setup perms
 RUN mkdir -p ${RANGER_DIST} ${RANGER_SCRIPTS} ${RANGER_HOME} && \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade the `ranger-base` Docker image from Ubuntu 22.04 (jammy) to Ubuntu 26.04 (resolute) to support the latest `apache-ranger` Python client, which requires Python ≥ 3.13.

- Switch base image to `eclipse-temurin:${RANGER_BASE_JAVA_VERSION}-jdk-resolute` (JDK 8 unchanged)
- Install `apache-ranger` into a dedicated venv at `/opt/venv` using system Python 3.14
- Fix `PATH` to include `${JAVA_HOME}/bin` and `/opt/venv/bin` so `java` and `python3` work as expected

## How was this patch tested?

- [x] Build base image: `./docker/build.sh` (or `docker build -f docker/Dockerfile -t apache/ranger-base:dev .` from repo root)
- [x] Verify Java: `docker run --rm apache/ranger-base:dev java -version` (JDK 8)
- [x] Verify Python: `docker run --rm apache/ranger-base:dev python3 --version` (3.14+)
- [x] Verify client: `docker run --rm apache/ranger-base:dev python3 -c "from apache_ranger.client.ranger_client import RangerClient"`
- [ ] CI builds `ranger-base` for jdk8/jdk11/jdk17 on amd64 and arm64
