### PR TITLE
Add ASF Allowlist Check workflow

### DIFF
--- a/.github/workflows/asf-allowlist-check.yaml
+++ b/.github/workflows/asf-allowlist-check.yaml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "ASF Allowlist Check"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    tags:
+      - '**'
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check actions
+        uses: apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3
+        with:
+          scan-glob: ".github/workflows/*.y*ml"


### PR DESCRIPTION
## What changes were proposed in this pull request?

GitHub workflows may fail silently when using any actions not allowed by ASF Infra. See https://github.com/apache/infrastructure-actions/issues/574 for details.

This change adds a new check that verifies action usage in workflows. See https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md


## How was this patch tested?

CI run: https://github.com/apache/ranger-tools/actions/runs/31066452015/job/92505059589?pr=12