### PR TITLE
RANGER-5733: Enable Dependabot for github-actions

### DIFF
--- a/.github/workflows/build-and-tag-ranger-image.yaml
+++ b/.github/workflows/build-and-tag-ranger-image.yaml
@@ -49,10 +49,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
         id: login
@@ -110,7 +110,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Add Docker Hub to targets
         if: ${{ env.DOCKERHUB_USER }}

--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -42,7 +42,7 @@ jobs:
       REGISTRIES: ghcr.io # docker.io is appended dynamically
     steps:
       - name: Generate tags
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ github.repository_owner }}/ranger-base

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Generate image ID
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/ranger-base
@@ -67,11 +67,11 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
         id: login

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # 'daily' only runs on weekdays
+      interval: "cron"
+      cronjob: "15 9 * * *"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable Dependabot for automated update of GitHub Actions. 
Add version tags in comment, which dependabot can update together with the commit hash.

https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#github-actions


## How was this patch tested?

Pending CI

`dependabot.yaml` will be tested after merge