### PR TITLE
Bump apache/ranger-base version in ranger docker image

### DIFF
--- a/release/Dockerfile.ranger
+++ b/release/Dockerfile.ranger
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG RANGER_BASE_IMAGE=apache/ranger-base
-ARG RANGER_BASE_VERSION=20260123-2-8
+ARG RANGER_BASE_VERSION=20260806-2-8
 
 FROM ${RANGER_BASE_IMAGE}:${RANGER_BASE_VERSION} AS ranger
 

--- a/release/README.md
+++ b/release/README.md
@@ -26,7 +26,7 @@
 To build the images, run the following commands from the `release` directory:
 
 ```bash
-export RANGER_VERSION=2.8.0
+export RANGER_VERSION=2.9.0
 docker build -f Dockerfile.ranger-postgres -t ranger-db:latest .
 docker build -f Dockerfile.ranger-solr -t ranger-solr:latest .
 docker build --build-arg RANGER_VERSION=${RANGER_VERSION} -f Dockerfile.ranger -t ranger:latest .


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump apache/ranger-base version in ranger docker image to use latest published version in DockerHub:

https://hub.docker.com/layers/apache/ranger-base/20260806-2-8/images/sha256-792fb6d1d486ca324082728cdff41c41d8661d4f49c9e59f9f900945969035f1

## How was this patch tested?

Tested locally